### PR TITLE
When ending the sim on Wand Refresh, check all actions

### DIFF
--- a/src/app/calc/eval/clickWand.ts
+++ b/src/app/calc/eval/clickWand.ts
@@ -242,7 +242,8 @@ export function clickWand(
 
     if (
       !fireUntilReload ||
-      (endOnRefresh && lastCalledAction?.action.id === 'RESET') ||
+      (endOnRefresh &&
+        calledActions!.filter((a) => a.action.id === 'RESET').length > 0) ||
       calledActions!.length === 0
     ) {
       break;


### PR DESCRIPTION
If we only check the last action called, there are some rare cases where Wand Refresh is called but isn't the last action, which would then never stop casting and hit the iteration limit.

See some discussion here: https://github.com/salinecitrine/noita-wand-simulator/pull/26

I'm pretty sure that this behavior is the one we want. It's a little harder to tell since in the game, isn't implemented in lua, as far as I can tell.