### PR TITLE
Fix bug with copy random spell

### DIFF
--- a/scripts/generate_gun_actions.py
+++ b/scripts/generate_gun_actions.py
@@ -134,7 +134,7 @@ syntaxPatterns = [
   PatternReplace(r'let (\w+) = \[]', r'let \1: any = []', flags=re.MULTILINE),
   PatternReplace(r'table.insert\(\s*(\w+)\s*,\s*(\w+)\s*\)', r'\1.push(\2)', flags=re.MULTILINE),
   PatternReplace(r'table.remove\(\s*(\w+)\s*,\s*(\w+)\s*\)', r'\1.splice(\2 - 1, 1)', flags=re.MULTILINE),
-  PatternReplace(r'(deck|actions|hand|discarded|types)\[([\w.]+)]', r'\1[\2 - 1]', flags=re.MULTILINE),
+  PatternReplace(r'(deck|actions|hand|discarded|types)\[([\w.\- ]+)]', r'\1[\2 - 1]', flags=re.MULTILINE),
   PatternReplace(r'string.sub\((.*?),(.*?),(.*?)\)', r'\1.substring(\2-1,\3)', flags=re.MULTILINE),
   PatternReplace(r'tonumber\(', r'Number.parseInt(', flags=re.MULTILINE),
   PatternReplace(

--- a/src/app/calc/__generated__/gun_actions.ts
+++ b/src/app/calc/__generated__/gun_actions.ts
@@ -7058,7 +7058,7 @@ export const actions: Action[] = [
 			if ( rnd <= deck.length )  {
 				data = deck[rnd - 1]
 		} 	else {
-				data = discarded[rnd - deck.length]
+				data = discarded[rnd - deck.length - 1]
 			}
 			
 			let checks = 0
@@ -7071,7 +7071,7 @@ export const actions: Action[] = [
 				if ( rnd <= deck.length )  {
 					data = deck[rnd - 1]
 			} 	else {
-					data = discarded[rnd - deck.length]
+					data = discarded[rnd - deck.length - 1]
 				}
 				
 				rec = check_recursion( data, recursion_level )
@@ -7114,7 +7114,7 @@ export const actions: Action[] = [
 			if ( rnd <= deck.length )  {
 				data = deck[rnd - 1]
 		} 	else {
-				data = discarded[rnd - deck.length]
+				data = discarded[rnd - deck.length - 1]
 			}
 			
 			let checks = 0
@@ -7127,7 +7127,7 @@ export const actions: Action[] = [
 				if ( rnd <= deck.length )  {
 					data = deck[rnd - 1]
 			} 	else {
-					data = discarded[rnd - deck.length]
+					data = discarded[rnd - deck.length - 1]
 				}
 				
 				rec = check_recursion( data, recursion_level )
@@ -7174,7 +7174,7 @@ export const actions: Action[] = [
 				if ( rnd <= deck.length )  {
 					data = deck[rnd - 1]
 			} 	else {
-					data = discarded[rnd - deck.length]
+					data = discarded[rnd - deck.length - 1]
 				}
 				
 				let checks = 0
@@ -7187,7 +7187,7 @@ export const actions: Action[] = [
 					if ( rnd <= deck.length )  {
 						data = deck[rnd - 1]
 				} 	else {
-						data = discarded[rnd - deck.length]
+						data = discarded[rnd - deck.length - 1]
 					}
 					
 					rec = check_recursion( data, recursion_level )


### PR DESCRIPTION
Hi,
I believe there is a bug with the generated code for copy random spell. The pattern matcher usually subtracts 1 from array indexing to account for lua not using 0-indexing, but it appears to miss a few lines in the copy random spell code. This change adds a few characters to the matcher to fix this issue.

Here is an example wand:
![image](https://github.com/salinecitrine/noita-wand-simulator/assets/29905424/d024ab3f-0ab4-4081-837a-a4790caec6fe)

Action call tree before this change: (an array out of bounds access causes the copied spell to be `undefined`)
![image](https://github.com/salinecitrine/noita-wand-simulator/assets/29905424/4d02506e-f130-43e1-9667-3bd98e8ef617)

Action call tree after this change:
![image](https://github.com/salinecitrine/noita-wand-simulator/assets/29905424/9054cc9c-534f-48aa-b39e-c49d68b8d43e)
